### PR TITLE
feat(auth): implement login RPC and enhance auth routes

### DIFF
--- a/apps/api-gateway/src/app/app.resolver.ts
+++ b/apps/api-gateway/src/app/app.resolver.ts
@@ -9,7 +9,7 @@ import {
   isAmqpSuccess,
 } from '@boundless/utils';
 
-const { userRegister } = RouteRegistry.auth;
+const { registerUser } = RouteRegistry.auth;
 
 @Resolver()
 export class AppResolver {
@@ -29,8 +29,8 @@ export class AppResolver {
     this.logger.log('📤 Sending create_user message via AmqpConnection');
 
     const response = await this.amqp.request<AmqpResponse<User>>({
-      exchange: userRegister.exchange,
-      routingKey: userRegister.routingKey,
+      exchange: registerUser.exchange,
+      routingKey: registerUser.routingKey,
       payload: input,
     });
 

--- a/apps/auth/src/app/auth/auth.service.ts
+++ b/apps/auth/src/app/auth/auth.service.ts
@@ -49,4 +49,30 @@ export class AuthService {
       user,
     };
   }
+
+  async login(email: string, password: string): Promise<AuthPayload> {
+    const user = await this.usersService.findUniqueUser({
+      email,
+    });
+
+    if (!user) {
+      throw new Error('Invalid credentials');
+    }
+
+    const valid = await argon2.verify(user.password, password);
+    if (!valid) {
+      throw new Error('Invalid credentials');
+    }
+
+    const accessToken = this.tokenService.generateAccessToken(user);
+    const refreshToken = await this.refreshTokenService.generateRefreshToken(
+      user.id,
+    );
+
+    return {
+      accessToken,
+      refreshToken,
+      user,
+    };
+  }
 }

--- a/libs/utils/src/lib/amqp/routes/auth.routes.ts
+++ b/libs/utils/src/lib/amqp/routes/auth.routes.ts
@@ -4,11 +4,29 @@ import { defineRoute } from './define-route';
 const exchange = ExchangeRegistry.auth;
 
 export const AuthRoutes = {
-  userRegister: defineRoute(exchange.command)('user.register', {
-    description: 'User registration command',
+  registerUser: defineRoute(exchange.command)('user.register', {
+    description: 'Initiates user registration process',
+    tags: ['registration', 'user'],
   }),
+  loginUser: defineRoute(exchange.command)('user.login', {
+    description: 'Handles user authentication',
+    tags: ['authentication'],
+  }),
+  refreshAuthToken: defineRoute(exchange.command)('token.refresh', {
+    description: 'Generates new access token using refresh token',
+    tags: ['authentication', 'tokens'],
+  }),
+
   userRegistered: defineRoute(exchange.event)('user.registered', {
-    description: 'User registered event',
+    description: 'Emitted after successful user registration',
+    tags: ['registration', 'user'],
   }),
-  authToken: defineRoute(exchange.command)('auth.token.refresh'),
+  userLoggedIn: defineRoute(exchange.event)('user.logged_in', {
+    description: 'Emitted after successful authentication',
+    tags: ['authentication'],
+  }),
+  authTokenRefreshed: defineRoute(exchange.event)('token.refreshed', {
+    description: 'Emitted when new tokens are generated',
+    tags: ['authentication', 'tokens'],
+  }),
 };


### PR DESCRIPTION
- Add login functionality to AuthService:
  * Verify user credentials with email/password
  * Generate access and refresh tokens
  * Return AuthPayload with tokens and user data
- Update AuthController with new RPC handlers:
  * loginUser - Handles authentication requests
  * Renamed token refresh RPC for consistency
  * Updated route references from userRegister to registerUser
- Enhance route definitions in AuthRoutes:
  * Added loginUser command route
  * Renamed authToken to refreshAuthToken for clarity
  * Added new event routes (userLoggedIn, authTokenRefreshed)
  * Added descriptive tags to all routes
- Update API Gateway to use renamed registerUser route
- Improve error handling for invalid credentials

Key Changes:
1. Login Implementation - Full email/password authentication flow
2. Route Naming - More consistent and descriptive route names
3. Event Expansion - Added events for login and token refresh
4. Documentation - Enhanced route descriptions and tags
5. Error Handling - Better credential validation