### PR TITLE
feat(utils): add date revival utility for GraphQL responses

### DIFF
--- a/apps/api-gateway/src/auth/auth.resolver.ts
+++ b/apps/api-gateway/src/auth/auth.resolver.ts
@@ -10,6 +10,7 @@ import { Logger, UseGuards } from '@nestjs/common';
 import { AuthenticatedUser } from '@boundless/types/interfaces';
 import { GqlAuthGuard } from '../utils/guards';
 import { CurrentUser } from '../utils/decorators';
+import { GraphQLResponseHelper } from '@boundless/utils';
 
 @Resolver()
 export class AuthResolver {
@@ -40,6 +41,7 @@ export class AuthResolver {
   @Query(() => User)
   async me(@CurrentUser() user: AuthenticatedUser): Promise<User> {
     this.logger.log(`🔑 Fetching user with ID: ${user.userId}`);
-    return this.authService.getUserById(user.userId);
+    const response = await this.authService.getUserById(user.userId);
+    return GraphQLResponseHelper.fromAmqpResponse(response);
   }
 }

--- a/apps/api-gateway/src/auth/auth.service.ts
+++ b/apps/api-gateway/src/auth/auth.service.ts
@@ -1,11 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
-import {
-  AuthPayload,
-  User,
-  LoginInput,
-  UserCreateInput,
-} from '@boundless/types/graphql';
+import { Prisma, User } from '@boundless/types/prisma';
+import { AuthPayload, LoginInput } from '@boundless/types/graphql';
 import {
   AmqpResponse,
   GraphQLResponseHelper,
@@ -21,7 +17,7 @@ export class AuthService {
 
   constructor(private readonly amqp: AmqpConnection) {}
 
-  async createUser(input: UserCreateInput): Promise<User> {
+  async createUser(input: Prisma.UserCreateInput): Promise<User> {
     const response = await this.amqp.request<AmqpResponse<User>>({
       exchange: registerUser.exchange,
       routingKey: registerUser.routingKey,
@@ -49,18 +45,11 @@ export class AuthService {
     return GraphQLResponseHelper.fromAmqpResponse(response);
   }
 
-  async getUserById(userId: number): Promise<User> {
-    const response = await this.amqp.request<AmqpResponse<User>>({
+  async getUserById(userId: number): Promise<AmqpResponse<User>> {
+    return await this.amqp.request<AmqpResponse<User>>({
       exchange: getUserById.exchange,
       routingKey: getUserById.routingKey,
       payload: { userId },
     });
-
-    if (!isAmqpSuccess(response)) {
-      this.logger.error('❌ getUserById RPC failed:', response.error);
-      throw new Error('Failed to retrieve user');
-    }
-
-    return GraphQLResponseHelper.fromAmqpResponse(response);
   }
 }

--- a/libs/utils/src/lib/gql/graphql.helper.ts
+++ b/libs/utils/src/lib/gql/graphql.helper.ts
@@ -1,6 +1,7 @@
 import { GraphQLError } from 'graphql';
 import { HttpStatus } from '@nestjs/common';
 import { AmqpError, AmqpResponse, isAmqpSuccess } from '../amqp/amqp.types';
+import { reviveDatesIterative } from './revive-date';
 
 export class GraphQLResponseHelper {
   private static httpStatusToCode(status: HttpStatus): string {
@@ -8,7 +9,10 @@ export class GraphQLResponseHelper {
   }
 
   static async fromAmqpResponse<T>(response: AmqpResponse<T>): Promise<T> {
-    if (isAmqpSuccess(response)) return await response.data;
+    if (isAmqpSuccess(response)) {
+      const revived = reviveDatesIterative(await response.data);
+      return revived;
+    }
     throw this.fromAmqpError(response.error);
   }
 

--- a/libs/utils/src/lib/gql/revive-date.ts
+++ b/libs/utils/src/lib/gql/revive-date.ts
@@ -1,0 +1,83 @@
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+export function reviveDatesIterative<T>(input: T): T {
+  if (input === null || input === undefined) return input;
+
+  if (typeof input === 'string' && ISO_DATE_RE.test(input)) {
+    return new Date(input) as unknown as T;
+  }
+
+  if (!isObjectOrArray(input)) return input;
+
+  const rootRef: { value: unknown } = { value: input as unknown };
+  const stack: Array<{
+    parent: Record<string | number, unknown>;
+    key: string | number;
+    value: unknown;
+  }> = [
+    {
+      parent: rootRef as unknown as Record<string | number, unknown>,
+      key: 'value',
+      value: input as unknown,
+    },
+  ];
+
+  const seen = new WeakSet<object>();
+
+  while (stack.length) {
+    const node = stack.pop();
+    if (!node) continue;
+
+    const { parent, key, value } = node;
+
+    if (value === null || value === undefined) continue;
+
+    if (typeof value === 'string' && ISO_DATE_RE.test(value)) {
+      parent[key] = new Date(value);
+      continue;
+    }
+
+    if (!isObjectOrArray(value)) continue;
+
+    if (seen.has(value as object)) continue;
+    seen.add(value as object);
+
+    if (Array.isArray(value)) {
+      for (let i = value.length - 1; i >= 0; i--) {
+        const child = value[i];
+        if (typeof child === 'string' && ISO_DATE_RE.test(child)) {
+          value[i] = new Date(child) as unknown;
+        } else if (isObjectOrArray(child)) {
+          stack.push({
+            parent: value as unknown as Record<string | number, unknown>,
+            key: i,
+            value: child,
+          });
+        }
+      }
+    } else {
+      for (const k of Object.keys(value)) {
+        const child = (value as Record<string, unknown>)[k];
+        if (typeof child === 'string' && ISO_DATE_RE.test(child)) {
+          (value as Record<string, unknown>)[k] = new Date(child);
+        } else if (isObjectOrArray(child)) {
+          stack.push({
+            parent: value as unknown as Record<string | number, unknown>,
+            key: k,
+            value: child,
+          });
+        }
+      }
+    }
+  }
+
+  return rootRef.value as T;
+}
+
+function isObjectOrArray(x: unknown): x is object {
+  if (x === null) return false;
+  const t = typeof x;
+  if (t !== 'object') return false;
+  const tag = Object.prototype.toString.call(x);
+  return tag === '[object Object]' || tag === '[object Array]';
+}


### PR DESCRIPTION
- Implement date revival utility to handle JSON-serialized dates:
  * Added reviveDatesIterative function
  * Supports nested objects and arrays
  * Efficient iterative implementation
  * Handles circular references
- Update GraphQLResponseHelper to use date revival:
  * Automatically revives dates in successful responses
  * Maintains existing error handling
- Improve API Gateway auth service:
  * Better type safety with Prisma types
  * Consistent response handling
  * Proper error propagation
- Enhance resolver layer:
  * Use GraphQLResponseHelper consistently
  * Better separation of concerns
- Add utility functions:
  * isObjectOrArray type guard
  * ISO date regex constant