### PR TITLE
Trans error

### DIFF
--- a/libs/utils/src/lib/amqp/errors/nestjs-error.ts
+++ b/libs/utils/src/lib/amqp/errors/nestjs-error.ts
@@ -14,7 +14,7 @@ export function formatNestJsError(
 
   const response = error.getResponse();
   let message: string;
-  let meta: Record<string, unknown> | undefined;
+  let nestMeta: Record<string, unknown> | undefined;
 
   if (typeof response === 'string') {
     message = response;
@@ -27,9 +27,9 @@ export function formatNestJsError(
           ? res.message.join(', ')
           : res.error || error.message;
 
-    meta = { ...res };
-    delete meta.message;
-    delete meta.error;
+    nestMeta = { ...res };
+    delete nestMeta.message;
+    delete nestMeta.error;
   }
 
   return {
@@ -39,7 +39,7 @@ export function formatNestJsError(
       message,
       code: `HTTP_${error.getStatus()}`,
       httpStatus: error.getStatus(),
-      meta: Object.keys(meta || {}).length ? meta : undefined,
+      meta: nestMeta ? { nest: nestMeta } : undefined,
     },
   };
 }

--- a/libs/utils/src/lib/amqp/errors/nestjs-error.ts
+++ b/libs/utils/src/lib/amqp/errors/nestjs-error.ts
@@ -27,7 +27,12 @@ export function formatNestJsError(
           ? res.message.join(', ')
           : res.error || error.message;
 
-    nestMeta = { ...res };
+    nestMeta = Object.keys(res).reduce<Record<string, unknown>>((acc, key) => {
+      if (key !== 'message' && key !== 'error') {
+        acc[key] = res[key];
+      }
+      return acc;
+    }, {});
     delete nestMeta.message;
     delete nestMeta.error;
   }

--- a/libs/utils/src/lib/amqp/errors/prisma-error.ts
+++ b/libs/utils/src/lib/amqp/errors/prisma-error.ts
@@ -39,12 +39,12 @@ export function formatPrismaError<T = unknown>(
           code: error.code,
           httpStatus: HttpStatus.CONFLICT,
           meta: {
-            ...error.meta,
+            target: targetFields,
             conflictingValues: Object.fromEntries(
               violations.map((v) => [v.field, v.value]),
             ),
+            ...error.meta,
           },
-          target: targetFields,
         },
       };
     }
@@ -105,4 +105,5 @@ export function formatPrismaError<T = unknown>(
       },
     };
   }
+  return undefined;
 }

--- a/libs/utils/src/lib/amqp/exchanges/registry.ts
+++ b/libs/utils/src/lib/amqp/exchanges/registry.ts
@@ -5,7 +5,7 @@ export const ExchangeRegistry = {
     command: defineExchange('auth', 'command'),
     event: defineExchange('auth', 'event'),
   },
-  post: {
+  user: {
     command: defineExchange('user', 'command'),
     event: defineExchange('user', 'event'),
   },

--- a/libs/utils/src/lib/gql/graphql.helper.ts
+++ b/libs/utils/src/lib/gql/graphql.helper.ts
@@ -27,7 +27,6 @@ export class GraphQLResponseHelper {
       httpStatus: error.httpStatus,
       type: error.type,
       meta: error.meta,
-      target: error.target,
     };
 
     if (error.originalError && typeof error.originalError === 'object') {

--- a/libs/utils/src/types/transport.ts
+++ b/libs/utils/src/types/transport.ts
@@ -2,36 +2,56 @@ import { HttpStatus } from '@nestjs/common';
 
 interface BaseTransportError {
   message: string;
+  code?: string;
+  httpStatus: HttpStatus;
   meta?: Record<string, unknown>;
+  originalError?: unknown;
 }
 
 interface HttpExceptionTransportError extends BaseTransportError {
   type: 'HttpException';
-  code: string;
-  httpStatus: HttpStatus;
 }
 
-interface PrismaErrorTransportError extends BaseTransportError {
+interface PrismaKnownRequestErrorTransportError extends BaseTransportError {
   type: 'PrismaClientKnownRequestError';
-  code: string;
-  httpStatus: HttpStatus;
 }
 
-interface BaseTransportError {
-  message: string;
-  meta?: Record<string, unknown>;
-  target?: string[];
-  originalError?: unknown;
+interface UniqueConstraintViolationError extends BaseTransportError {
+  type: 'UniqueConstraintViolation';
+  meta: {
+    target?: string[];
+    conflictingValues: Record<string, unknown>;
+  };
+}
+
+interface PrismaUnknownRequestErrorTransportError extends BaseTransportError {
+  type: 'PrismaClientUnknownRequestError';
+}
+
+interface PrismaInitializationErrorTransportError extends BaseTransportError {
+  type: 'PrismaClientInitializationError';
+}
+
+interface PrismaRustPanicErrorTransportError extends BaseTransportError {
+  type: 'PrismaClientRustPanicError';
+}
+
+interface PrismaValidationErrorTransportError extends BaseTransportError {
+  type: 'PrismaClientValidationError';
 }
 
 interface UnknownErrorTransportError extends BaseTransportError {
   type: 'UnknownError';
-  httpStatus: HttpStatus;
 }
 
 export type TransportError =
   | HttpExceptionTransportError
-  | PrismaErrorTransportError
+  | PrismaKnownRequestErrorTransportError
+  | UniqueConstraintViolationError
+  | PrismaUnknownRequestErrorTransportError
+  | PrismaInitializationErrorTransportError
+  | PrismaRustPanicErrorTransportError
+  | PrismaValidationErrorTransportError
   | UnknownErrorTransportError;
 
 export type TransportResponse<T> =

--- a/libs/utils/src/types/transport.ts
+++ b/libs/utils/src/types/transport.ts
@@ -1,18 +1,35 @@
 import { HttpStatus } from '@nestjs/common';
 
+interface BaseTransportError {
+  message: string;
+  meta?: Record<string, unknown>;
+}
+
+interface HttpExceptionTransportError extends BaseTransportError {
+  type: 'HttpException';
+  code: string;
+  httpStatus: HttpStatus;
+}
+
+interface PrismaErrorTransportError extends BaseTransportError {
+  type: 'PrismaClientKnownRequestError';
+  code: string;
+  httpStatus: HttpStatus;
+}
+
+interface UnknownErrorTransportError extends BaseTransportError {
+  type: 'UnknownError';
+  httpStatus: HttpStatus;
+}
+
+export type TransportError =
+  | HttpExceptionTransportError
+  | PrismaErrorTransportError
+  | UnknownErrorTransportError;
+
 export type TransportResponse<T> =
   | { success: true; data: T }
   | { success: false; error: TransportError };
-
-export interface TransportError {
-  type?: string;
-  message: string;
-  code?: string;
-  httpStatus?: HttpStatus;
-  meta?: Record<string, unknown>;
-  target?: string[];
-  originalError?: unknown;
-}
 
 export function isTransportSuccess<T>(
   response: TransportResponse<T>,

--- a/libs/utils/src/types/transport.ts
+++ b/libs/utils/src/types/transport.ts
@@ -17,6 +17,13 @@ interface PrismaErrorTransportError extends BaseTransportError {
   httpStatus: HttpStatus;
 }
 
+interface BaseTransportError {
+  message: string;
+  meta?: Record<string, unknown>;
+  target?: string[];
+  originalError?: unknown;
+}
+
 interface UnknownErrorTransportError extends BaseTransportError {
   type: 'UnknownError';
   httpStatus: HttpStatus;


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Restructure TransportError as discriminated union with explicit variants

- Improve NestJS error formatting with cleaner metadata structure

- Fix AMQP exchange registry naming from 'post' to 'user'


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TransportError Interface"] --> B["Discriminated Union"]
  B --> C["HttpException Variant"]
  B --> D["PrismaError Variant"] 
  B --> E["UnknownError Variant"]
  F["NestJS Error Handler"] --> G["Nested Meta Structure"]
  H["AMQP Registry"] --> I["Corrected Exchange Names"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transport.ts</strong><dd><code>Restructure TransportError as discriminated union</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/utils/src/types/transport.ts

<ul><li>Replace generic <code>TransportError</code> interface with discriminated union<br> <li> Create specific error variants: <code>HttpExceptionTransportError</code>, <br><code>PrismaErrorTransportError</code>, <code>UnknownErrorTransportError</code><br> <li> Add <code>BaseTransportError</code> interface for shared properties<br> <li> Improve type safety with strongly typed error categories</ul>


</details>


  </td>
  <td><a href="https://github.com/tgenericx/boundless/pull/70/files#diff-2a960a1b62a6810eca3e113d9bc820da7b9fd6daf21039b2c73f8b67b98904ea">+27/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nestjs-error.ts</strong><dd><code>Improve NestJS error metadata structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/utils/src/lib/amqp/errors/nestjs-error.ts

<ul><li>Rename <code>meta</code> variable to <code>nestMeta</code> for clarity<br> <li> Nest framework-specific metadata under 'nest' property<br> <li> Maintain cleaner separation between error data and framework metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/tgenericx/boundless/pull/70/files#diff-ac05a5c8d7cd45a54d25ff80ca2547560c511c436a801ec244c658385944f0ca">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry.ts</strong><dd><code>Fix AMQP exchange registry naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

libs/utils/src/lib/amqp/exchanges/registry.ts

<ul><li>Change exchange name from 'post' to 'user' in ExchangeRegistry<br> <li> Maintain same command/event structure with corrected naming</ul>


</details>


  </td>
  <td><a href="https://github.com/tgenericx/boundless/pull/70/files#diff-ddbffc521b896c5eb26c439c77aab44bae8a7d25f4a09cc17d0ab63b3b4c3fbe">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

